### PR TITLE
Make Comment.update_author optional

### DIFF
--- a/src/issue_model.rs
+++ b/src/issue_model.rs
@@ -296,7 +296,7 @@ pub struct Comment {
     pub created: DateTime<Utc>,
     pub id: String,
     #[serde(rename = "updateAuthor")]
-    pub update_author: User,
+    pub update_author: Option<User>,
     pub updated: DateTime<Utc>,
     pub visibility: Option<Visibility>,
     #[serde(rename = "self")]


### PR DESCRIPTION
Jira API doesn't guarantee that `updateAuthor` field is present on every comment. Comments created by certain bot accounts might lack this field, causing deserialization errors like:
```
missing field `updateAuthor` at line 1 column NNNNNN
```